### PR TITLE
dont parse .json files

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 'use strict';
 
 var through = require('through')
-  , redeyed = require('redeyed');
+  , redeyed = require('redeyed')
+  , path = require('path');
 
 var config = {
   Keyword: { 
@@ -28,5 +29,7 @@ module.exports = function (file) {
     }
     this.emit('end');
   }
-  return through(ondata, onend);
+  return (path.extname(file) === '.json')
+    ? through()
+    : through(ondata, onend);
 };


### PR DESCRIPTION
This patch makes it so `varify` doesn't bug out when encountering a `.json` file. Should work in [Node >= 0.10](https://nodejs.org/docs/v0.10.0/api/stream.html#stream_class_stream_passthrough). Probably a patch release. Thanks! :sparkles: